### PR TITLE
Mutate data, not props

### DIFF
--- a/src/VueLazyImage.vue
+++ b/src/VueLazyImage.vue
@@ -15,18 +15,19 @@
   export default {
     data() {
       return {
+        imgClassMutable: this.imgClass,
         show: false
       }
     },
     computed: {
       _class() {
         if (this.show) {
-            if(this.imgClass instanceof Array) {
-                this.imgClass.push('show');
+            if(this.imgClassMutable instanceof Array) {
+                this.imgClassMutable.push('show');
             }
-            else this.imgClass += ' show';
+            else this.imgClassMutable += ' show';
         }
-        return this.imgClass;
+        return this.imgClassMutable;
       }
     },
     mounted() {


### PR DESCRIPTION
This PR removes error `[Vue warn]: Avoid mutating a prop directly since the value will be overwritten whenever the parent component re-renders. Instead, use a data or computed property based on the prop's value. Prop being mutated: "imgClass"`

and removes vue antipattern of mutating the props.